### PR TITLE
Use new type of thunk for `gitignore.nix`

### DIFF
--- a/dep/gitignore.nix/default.nix
+++ b/dep/gitignore.nix/default.nix
@@ -1,8 +1,2 @@
 # DO NOT HAND-EDIT THIS FILE
-let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
-  if !fetchSubmodules && !private then builtins.fetchTarball {
-    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
-    inherit owner repo rev sha256 fetchSubmodules private;
-  };
-in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))
+import (import ./thunk.nix)

--- a/dep/gitignore.nix/thunk.nix
+++ b/dep/gitignore.nix/thunk.nix
@@ -1,0 +1,9 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json


### PR DESCRIPTION
I figure this will be less confusing for anyone reading the code: no need to wonder why the two thunks are different.