### PR TITLE
Fix removal of .git from default destination

### DIFF
--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -77,7 +77,6 @@ import Data.Foldable (toList)
 import Data.Function
 import Data.Functor ((<&>))
 import qualified Data.List as L
-import Data.List (stripPrefix)
 import Data.List.NonEmpty (NonEmpty(..), nonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map (Map)
@@ -506,9 +505,8 @@ createThunk' config = do
     (untagName <$> _thunkCreateConfig_branch config)
     (T.pack . show <$> _thunkCreateConfig_rev config)
   let trailingDirectoryName = reverse . takeWhile (/= '/') . dropWhile (=='/') . reverse
-      stripSuffix s = fmap reverse . stripPrefix s . reverse
       dropDotGit :: FilePath -> FilePath
-      dropDotGit origName = fromMaybe origName $ stripSuffix ".git" origName
+      dropDotGit origName = fromMaybe origName $ stripExtension "git" origName
       defaultDestinationForGitUri :: GitUri -> FilePath
       defaultDestinationForGitUri = dropDotGit . trailingDirectoryName . T.unpack . URI.render . unGitUri
       destination = fromMaybe (defaultDestinationForGitUri $ _thunkCreateConfig_uri config) $ _thunkCreateConfig_destination config


### PR DESCRIPTION
Fixes #5 

There apparently was already logic in there to do this, but it wasn't correct (it reversed the input but didn't reverse the extension). However, `System.FilePath` already has a solution for this.