### PR TITLE
Bump the cryptonite version bound.

### DIFF
--- a/nix-thunk.cabal
+++ b/nix-thunk.cabal
@@ -38,7 +38,7 @@ library
     , cli-git               >=0.1.0.1  && <0.2
     , cli-nix               >=0.1.0.1  && <0.2
     , containers            >=0.6.0.1  && <0.7
-    , cryptonite            >=0.25     && <0.29
+    , cryptonite            >=0.25     && <0.30
     , data-default          >=0.7.1.1  && <0.8
     , directory             >=1.3.3.0  && <1.4
     , either                >=5.0.1.1  && <5.1


### PR DESCRIPTION
This fixes `haskellPackages.nix-thunk` on nixos-unstable.