### PR TITLE
Use static which to locate nix-prefetch utils

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -31,10 +31,12 @@ jobs:
 
     - name: Install dependencies
       run: |
-        cabal update
-        cabal build --only-dependencies --enable-tests --enable-benchmarks
         echo -e "#!/bin/sh\necho \"CI build\"" >> print-nixpkgs-path
-        chmod 755 print-nixpkgs-path
+        touch nix-prefetch-url
+        touch nix-prefetch-git
+        chmod 755 print-nixpkgs-path nix-prefetch-url nix-prefetch-git
+        env PATH=.:$PATH cabal update
+        env PATH=.:$PATH cabal build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
       run: env PATH=.:$PATH cabal build --enable-tests --enable-benchmarks all
     - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for nix-thunk
 
+## 0.5.1.0
+
+* Bump to cli-nix 0.2.0.0; This ensures that `nix-prefetch-git` can always be found.
+
 ## 0.5.0.0
 
 * Fix a critical bug where v6 thunks can not be used to fetch non-GitHub repositories. Please update all your thunks to use the new v7 thunk spec.

--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,7 @@ in rec {
     overrides = self: super: {
       which = self.callCabal2nix "which" (thunkSource ./dep/which) {};
       cli-extras = self.callCabal2nix "cli-extras" (thunkSource ./dep/cli-extras) {};
-      cli-nix = self.callCabal2nix "cli-nix" (thunkSource ./dep/cli-nix) {};
+      cli-nix = (import (thunkSource ./dep/cli-nix + "/overlays.nix")).cli-nix pkgs self;
       cli-git = pkgs.haskell.lib.overrideCabal (self.callCabal2nix "cli-git" (thunkSource ./dep/cli-git) {}) {
         librarySystemDepends = with pkgs; [
           git

--- a/dep/cli-nix/github.json
+++ b/dep/cli-nix/github.json
@@ -3,6 +3,6 @@
   "repo": "cli-nix",
   "branch": "master",
   "private": false,
-  "rev": "e881631b0429614c215f21d58fb7e4c55df64705",
-  "sha256": "0axw3jyxf5f0yjdfh1x8i3vrayxfrfpg0gcfxbsp2xgim4qjh37x"
+  "rev": "eed93d0fe974fe1b6bc05ac34495bca9da4442e3",
+  "sha256": "1yq2jgj37mb9d1z1cgan7h3jbj8j9gwsirjw3nndacn469id7zlv"
 }

--- a/nix-thunk.cabal
+++ b/nix-thunk.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               nix-thunk
-version:            0.5.0.0
+version:            0.5.1.0
 license:            BSD3
 license-file:       LICENSE
 copyright:          Obsidian Systems LLC 2020-2022

--- a/nix-thunk.cabal
+++ b/nix-thunk.cabal
@@ -36,7 +36,7 @@ library
     , bytestring            >=0.10.8.2 && <0.11
     , cli-extras            >=0.2.1.0  && <0.3
     , cli-git               >=0.2.0.0  && <0.3
-    , cli-nix               >=0.1.0.1  && <0.2
+    , cli-nix               >=0.2.0.0  && <0.3
     , containers            >=0.6.0.1  && <0.7
     , cryptonite            >=0.25     && <0.30
     , data-default          >=0.7.1.1  && <0.8

--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -263,14 +263,14 @@ getNixSha256ForUriUnpacked
 getNixSha256ForUriUnpacked uri =
   withExitFailMessage ("nix-prefetch-url: Failed to determine sha256 hash of URL " <> gitUriToText uri) $ do
     [hash] <- fmap T.lines $ readProcessAndLogOutput (Debug, Debug) $
-      proc "nix-prefetch-url" ["--unpack", "--type", "sha256", T.unpack $ gitUriToText uri]
+      proc nixPrefetchUrlPath ["--unpack", "--type", "sha256", T.unpack $ gitUriToText uri]
     pure hash
 
 nixPrefetchGit :: MonadNixThunk m => GitUri -> Text -> Bool -> m NixSha256
 nixPrefetchGit uri rev fetchSubmodules =
   withExitFailMessage ("nix-prefetch-git: Failed to determine sha256 hash of Git repo " <> gitUriToText uri <> " at " <> rev) $ do
     out <- readProcessAndLogStderr Debug $
-      proc "nix-prefetch-git" $ filter (/="")
+      proc nixPrefetchGitPath $ filter (/="")
         [ "--url", T.unpack $ gitUriToText uri
         , "--rev", T.unpack rev
         , if fetchSubmodules then "--fetch-submodules" else ""


### PR DESCRIPTION
Pending merge of https://github.com/obsidiansystems/cli-nix/pull/2
Without this change, `nix-thunk` fails for me when used with thunks of private repos:
```nix-thunk: nix-prefetch-git: createProcess: runInteractiveProcess: exec: does not exist (No such file or directory)```
which currently prevents it from being a drop-in replacement of `ob thunk`.