### PR TITLE
Add new Spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for nix-thunk
 
+## 0.4.0.0
+
+* The default thunk specification ("v6") now uses a pinned version of nixpkgsk, rather than the magic `<nixpkgs>`, for fetching thunks. This ensures that thunks can be fetched even in an environment where `NIX_PATH` is unset.
+
 ## 0.3.0.0
 
 * Fix readThunk when thunk is checked out [#4](https://github.com/obsidiansystems/nix-thunk/pull/4)

--- a/nix-thunk.cabal
+++ b/nix-thunk.cabal
@@ -1,9 +1,9 @@
 cabal-version:      >=1.10
 name:               nix-thunk
-version:            0.3.0.0
+version:            0.4.0.0
 license:            BSD3
 license-file:       LICENSE
-copyright:          Obsidian Systems LLC 2020
+copyright:          Obsidian Systems LLC 2020-2022
 maintainer:         maintainer@obsidian.systems
 author:             Obsidian Systems LLC
 bug-reports:        https://github.com/obsidiansystems/nix-thunk

--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -562,8 +562,9 @@ setThunk thunkConfig target gs branch = do
 -- This tool will only ever produce the newest one when it writes a thunk.
 gitHubThunkSpecs :: NonEmpty ThunkSpec
 gitHubThunkSpecs =
-  gitHubThunkSpecV5 :|
-  [ gitHubThunkSpecV4
+  gitHubThunkSpecV6 :|
+  [ gitHubThunkSpecV5
+  , gitHubThunkSpecV4
   , gitHubThunkSpecV3
   , gitHubThunkSpecV2
   , gitHubThunkSpecV1
@@ -615,7 +616,7 @@ gitHubThunkSpecV4 = legacyGitHubThunkSpec "github-v4" $ T.unlines
   , "  };"
   , "in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))"
   ]
-
+  
 legacyGitHubThunkSpec :: Text -> Text -> ThunkSpec
 legacyGitHubThunkSpec name loader = ThunkSpec name $ Map.fromList
   [ ("default.nix", ThunkFileSpec_FileMatches $ T.strip loader)
@@ -623,7 +624,7 @@ legacyGitHubThunkSpec name loader = ThunkSpec name $ Map.fromList
   , (attrCacheFileName, ThunkFileSpec_AttrCache)
   , (".git", ThunkFileSpec_CheckoutIndicator)
   ]
-
+  
 gitHubThunkSpecV5 :: ThunkSpec
 gitHubThunkSpecV5 = mkThunkSpec "github-v5" "github.json" parseGitHubJsonBytes [here|
 # DO NOT HAND-EDIT THIS FILE
@@ -637,14 +638,31 @@ let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256
 in fetch json
 |]
 
+gitHubThunkSpecV6 :: ThunkSpec
+gitHubThunkSpecV6 = mkThunkSpec "github-v6" "github.json" parseGitHubJsonBytes [here|
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (builtins.fetchTarball { 
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json
+|]
+
 parseGitHubJsonBytes :: LBS.ByteString -> Either String ThunkPtr
 parseGitHubJsonBytes = parseJsonObject $ parseThunkPtr $ \v ->
   ThunkSource_GitHub <$> parseGitHubSource v <|> ThunkSource_Git <$> parseGitSource v
 
 gitThunkSpecs :: NonEmpty ThunkSpec
 gitThunkSpecs =
-  gitThunkSpecV5 :|
-  [ gitThunkSpecV4
+  gitThunkSpecV6 :|
+  [ gitThunkSpecV5
+  , gitThunkSpecV4
   , gitThunkSpecV3
   , gitThunkSpecV2
   , gitThunkSpecV1
@@ -723,6 +741,27 @@ let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, pr
     url = realUrl; inherit rev;
     ${if branch == null then null else "ref"} = branch;
   } else (import <nixpkgs> {}).fetchgit {
+    url = realUrl; inherit rev sha256;
+  };
+  json = builtins.fromJSON (builtins.readFile ./git.json);
+in fetch json
+|]
+
+gitThunkSpecV6 :: ThunkSpec
+gitThunkSpecV6 = mkThunkSpec "git-v6" "git.json" parseGitJsonBytes [here|
+# DO NOT HAND-EDIT THIS FILE
+let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, private ? false, ...}:
+  let realUrl = let firstChar = builtins.substring 0 1 url; in
+    if firstChar == "/" then /. + url
+    else if firstChar == "." then ./. + url
+    else url;
+  in if !fetchSubmodules && private then builtins.fetchGit {
+    url = realUrl; inherit rev;
+    ${if branch == null then null else "ref"} = branch;
+  } else (builtins.fetchTarball { 
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}).fetchgit {
     url = realUrl; inherit rev sha256;
   };
   json = builtins.fromJSON (builtins.readFile ./git.json);

--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -616,7 +616,7 @@ gitHubThunkSpecV4 = legacyGitHubThunkSpec "github-v4" $ T.unlines
   , "  };"
   , "in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))"
   ]
-  
+
 legacyGitHubThunkSpec :: Text -> Text -> ThunkSpec
 legacyGitHubThunkSpec name loader = ThunkSpec name $ Map.fromList
   [ ("default.nix", ThunkFileSpec_FileMatches $ T.strip loader)
@@ -624,7 +624,7 @@ legacyGitHubThunkSpec name loader = ThunkSpec name $ Map.fromList
   , (attrCacheFileName, ThunkFileSpec_AttrCache)
   , (".git", ThunkFileSpec_CheckoutIndicator)
   ]
-  
+
 gitHubThunkSpecV5 :: ThunkSpec
 gitHubThunkSpecV5 = mkThunkSpec "github-v5" "github.json" parseGitHubJsonBytes [here|
 # DO NOT HAND-EDIT THIS FILE
@@ -638,13 +638,17 @@ let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256
 in fetch json
 |]
 
+-- | Specification for GitHub thunks which use a specific, pinned
+-- version of nixpkgs for fetching, rather than using @<nixpkgs>@ from
+-- @NIX_PATH@. The "v6" specs ensure that thunks can be fetched even
+-- when @NIX_PATH@ is unset.
 gitHubThunkSpecV6 :: ThunkSpec
 gitHubThunkSpecV6 = mkThunkSpec "github-v6" "github.json" parseGitHubJsonBytes [here|
 # DO NOT HAND-EDIT THIS FILE
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (builtins.fetchTarball { 
+  } else (builtins.fetchTarball {
   url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
   sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
 }).fetchFromGitHub {
@@ -747,6 +751,10 @@ let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, pr
 in fetch json
 |]
 
+-- | Specification for Git thunks which use a specific, pinned version
+-- of nixpkgs for fetching, rather than using @<nixpkgs>@ from
+-- @NIX_PATH@. The "v6" specs ensure that thunks can be fetched even
+-- when @NIX_PATH@ is unset.
 gitThunkSpecV6 :: ThunkSpec
 gitThunkSpecV6 = mkThunkSpec "git-v6" "git.json" parseGitJsonBytes [here|
 # DO NOT HAND-EDIT THIS FILE
@@ -758,7 +766,7 @@ let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, pr
   in if !fetchSubmodules && private then builtins.fetchGit {
     url = realUrl; inherit rev;
     ${if branch == null then null else "ref"} = branch;
-  } else (builtins.fetchTarball { 
+  } else (builtins.fetchTarball {
   url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
   sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
 }).fetchgit {


### PR DESCRIPTION
This PR creates a new Spec (v6) to change the current use of <nixpkgs> to a pinned nixpkgs.