### PR TITLE
Fix v6 thunk nixpkgs fetching

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,6 +1,6 @@
 name: github-action
 
-on: [push, pull_request] 
+on: [push, pull_request]
 
 jobs:
   build:
@@ -33,7 +33,9 @@ jobs:
       run: |
         cabal update
         cabal build --only-dependencies --enable-tests --enable-benchmarks
+        echo -e "#!/bin/sh\necho \"CI build\"" >> print-nixpkgs-path
+        chmod 755 print-nixpkgs-path
     - name: Build
-      run: cabal build --enable-tests --enable-benchmarks all
+      run: env PATH=.:$PATH cabal build --enable-tests --enable-benchmarks all
     - name: Run tests
-      run: cabal test all
+      run: env PATH=.:$PATH cabal test all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for nix-thunk
 
+## 0.5.0.0
+
+* Fix a critical bug where v6 thunks can not be used to fetch non-GitHub repositories. Please update all your thunks to use the new v7 thunk spec.
+  Updating your thunk can be done by running `nix-thunk unpack $path; nix-thunk pack $path`.
+
 ## 0.4.0.0
 
 * The default thunk specification ("v6") now uses a pinned version of nixpkgs, rather than the magic `<nixpkgs>`, for fetching thunks. This ensures that thunks can be fetched even in an environment where `NIX_PATH` is unset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix a critical bug where v6 thunks can not be used to fetch non-GitHub repositories. Please update all your thunks to use the new v7 thunk spec.
   Updating your thunk can be done by running `nix-thunk unpack $path; nix-thunk pack $path`.
+* Building a functional `nix-thunk` _must_ be done using the included Nix derivation.
 
 ## 0.4.0.0
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ nix-thunk does this by creating and managing "thunks" - directories that stand i
 nix-env -f https://github.com/obsidiansystems/nix-thunk/archive/master.tar.gz -iA command
 ```
 
+**WARNING**: It is _not_ possible to compile `nix-thunk` without Nix. To ensure that packed thunks are buildable even in environments where diamond paths are unavailable (specifically `<nixpkgs>`), `nix-thunk` _must_ be built with knowledge of a known-good nixpkgs, _and_ for `nix-thunk` to be able to manipulate these thunks, it must _always_ be the same version of nixpkgs.
+
 ## Command Usage
 
 ### Create a dependency

--- a/dep/cli-extras/thunk.nix
+++ b/dep/cli-extras/thunk.nix
@@ -2,10 +2,7 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
-  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-}) {}).fetchFromGitHub {
+  } else (import "/nix/store/qjg458n31xk1l6lj26c3b871d4i4is98-source" {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/cli-extras/thunk.nix
+++ b/dep/cli-extras/thunk.nix
@@ -2,10 +2,10 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (builtins.fetchTarball {
+  } else (import (builtins.fetchTarball {
   url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
   sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-}).fetchFromGitHub {
+}) {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/cli-git/thunk.nix
+++ b/dep/cli-git/thunk.nix
@@ -2,10 +2,7 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
-  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-}) {}).fetchFromGitHub {
+  } else (import "/nix/store/qjg458n31xk1l6lj26c3b871d4i4is98-source" {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/cli-git/thunk.nix
+++ b/dep/cli-git/thunk.nix
@@ -2,10 +2,10 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (builtins.fetchTarball {
+  } else (import (builtins.fetchTarball {
   url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
   sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-}).fetchFromGitHub {
+}) {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/cli-nix/thunk.nix
+++ b/dep/cli-nix/thunk.nix
@@ -2,10 +2,7 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
-  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-}) {}).fetchFromGitHub {
+  } else (import "/nix/store/qjg458n31xk1l6lj26c3b871d4i4is98-source" {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/cli-nix/thunk.nix
+++ b/dep/cli-nix/thunk.nix
@@ -2,10 +2,10 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (builtins.fetchTarball {
+  } else (import (builtins.fetchTarball {
   url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
   sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-}).fetchFromGitHub {
+}) {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/github/thunk.nix
+++ b/dep/github/thunk.nix
@@ -2,7 +2,10 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/github/thunk.nix
+++ b/dep/github/thunk.nix
@@ -2,10 +2,7 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
-  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-}) {}).fetchFromGitHub {
+  } else (import "/nix/store/qjg458n31xk1l6lj26c3b871d4i4is98-source" {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/gitignore.nix/thunk.nix
+++ b/dep/gitignore.nix/thunk.nix
@@ -2,7 +2,10 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/gitignore.nix/thunk.nix
+++ b/dep/gitignore.nix/thunk.nix
@@ -2,10 +2,7 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
-  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-}) {}).fetchFromGitHub {
+  } else (import "/nix/store/qjg458n31xk1l6lj26c3b871d4i4is98-source" {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/which/thunk.nix
+++ b/dep/which/thunk.nix
@@ -2,7 +2,10 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/which/thunk.nix
+++ b/dep/which/thunk.nix
@@ -2,10 +2,7 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
-  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-}) {}).fetchFromGitHub {
+  } else (import "/nix/store/qjg458n31xk1l6lj26c3b871d4i4is98-source" {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/nix-thunk.cabal
+++ b/nix-thunk.cabal
@@ -61,6 +61,8 @@ library
     , unix                  >=2.7.2.2  && <2.8
     , which                 >=0.2      && <0.3
     , yaml                  >=0.11.1.2 && <0.12
+    , process               >=1.6.0.0  && <1.7
+    , template-haskell      >=2.15.0.0 && <2.19
 
 executable nix-thunk
   main-is:          src-bin/nix-thunk.hs

--- a/nix-thunk.cabal
+++ b/nix-thunk.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               nix-thunk
-version:            0.4.0.0
+version:            0.5.0.0
 license:            BSD3
 license-file:       LICENSE
 copyright:          Obsidian Systems LLC 2020-2022

--- a/nix-thunk.cabal
+++ b/nix-thunk.cabal
@@ -62,7 +62,7 @@ library
     , which                 >=0.2      && <0.3
     , yaml                  >=0.11.1.2 && <0.12
     , process               >=1.6.0.0  && <1.7
-    , template-haskell      >=2.15.0.0 && <2.19
+    , template-haskell      >=2.14.0.0 && <2.19
 
 executable nix-thunk
   main-is:          src-bin/nix-thunk.hs

--- a/release.nix
+++ b/release.nix
@@ -14,4 +14,4 @@ in
   builtins.listToAttrs (map (v: lib.nameValuePair (mkName v) (import ./. {
     ghc = v.compiler;
     pkgs = import (./dep/ci + "/${v.nixpkgs}") {};
-  }).command) versions) // { tests = import ./tests {} }
+  }).command) versions) // { tests = import ./tests.nix {}; }

--- a/release.nix
+++ b/release.nix
@@ -14,4 +14,4 @@ in
   builtins.listToAttrs (map (v: lib.nameValuePair (mkName v) (import ./. {
     ghc = v.compiler;
     pkgs = import (./dep/ci + "/${v.nixpkgs}") {};
-  }).command) versions)
+  }).command) versions) // { tests = import ./tests {} }

--- a/tests.nix
+++ b/tests.nix
@@ -1,0 +1,145 @@
+{
+  supportedSystems ? [ builtins.currentSystem ]
+}:
+let
+  nix-thunk = import ./default.nix {};
+  # Get a version of nixpkgs corresponding to release-22.05, which
+  # contains the python based tests and recursive nix.
+  pkgs = import (builtins.fetchTarball https://github.com/nixos/nixpkgs/archive/478f3cbc8448b5852539d785fbfe9a53304133be.tar.gz) {};
+  sshKeys   = import (pkgs.path + /nixos/tests/ssh-keys.nix) pkgs;
+  make-test = import (pkgs.path + /nixos/tests/make-test-python.nix);
+  snakeOilPrivateKey = sshKeys.snakeOilPrivateKey.text;
+  snakeOilPublicKey = sshKeys.snakeOilPublicKey;
+in
+  make-test ({...}: {
+    name  = "nix-thunk";
+    nodes = {
+      githost = {
+        networking.firewall.allowedTCPPorts = [ 22 80 443 ];
+        services.openssh = {
+          enable = true;
+        };
+        environment.systemPackages = [
+          pkgs.git
+        ];
+        users.users.root.openssh.authorizedKeys.keys = [
+          snakeOilPublicKey
+        ];
+      };
+
+      client = {
+        imports = [
+          (pkgs.path + /nixos/modules/installer/cd-dvd/channel.nix)
+        ];
+        nix.useSandbox = false;
+        nix.binaryCaches = [];
+        environment.systemPackages = [
+          pkgs.nix-prefetch-git
+          nix-thunk.command
+          pkgs.git
+        ];
+      };
+    };
+
+    testScript =
+      let
+        privateKeyFile = pkgs.writeText "id_rsa" ''${snakeOilPrivateKey}'';
+        thunkableSample = pkgs.writeText "default.nix" ''
+          let pkgs = import <nixpkgs> {}; in pkgs.git
+        '';
+        invalidThunkableSample = pkgs.writeText "default.nix" ''
+          let pkgs = import <nixpkgs> {}; in pkgtypo.git
+        '';
+        sshConfigFile = pkgs.writeText "ssh_config" ''
+          Host *
+            StrictHostKeyChecking no
+            UserKnownHostsFile=/dev/null
+            ConnectionAttempts=1
+            ConnectTimeout=1
+            IdentityFile=~/.ssh/id_rsa
+            User=root
+        '';
+      in ''
+      start_all()
+
+      with subtest("nix-thunk is installed and git can be configured"):
+        client.succeed("nix-thunk --help")
+        client.succeed('git config --global user.email "you@example.com"')
+        client.succeed('git config --global user.name "Your Name"')
+
+      githost.wait_for_open_port("22")
+
+      with subtest("the client can access the server via ssh"):
+        client.succeed("mkdir -p ~/.ssh/")
+        client.succeed("cp ${privateKeyFile} ~/.ssh/id_rsa")
+        client.succeed("chmod 600 ~/.ssh/id_rsa")
+        client.wait_until_succeeds(
+          "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa githost true"
+        )
+        client.succeed("cp ${sshConfigFile} ~/.ssh/config")
+        client.wait_until_succeeds("ssh githost true")
+
+      with subtest("a remote bare repo can be started"):
+        githost.succeed("mkdir -p ~/myorg/myapp.git")
+        githost.succeed("cd ~/myorg/myapp.git && git init --bare")
+
+      with subtest("a git project can be configured with a remote using ssh"):
+        client.succeed("mkdir -p ~/code/myapp")
+        client.succeed("cd ~/code/myapp && git init")
+        client.succeed("cp ${thunkableSample} ~/code/myapp/default.nix")
+        client.succeed("cd ~/code/myapp && git add .")
+
+        client.succeed('cd ~/code/myapp && git commit -m "Initial"')
+        client.succeed("cd ~/code/myapp && git remote add origin root@githost:/root/myorg/myapp.git")
+
+      with subtest("pushing code to the remote"):
+        client.succeed("cd ~/code/myapp && git push -u origin master")
+        client.succeed("cd ~/code/myapp && git status")
+
+      with subtest("nix-thunk can pack and unpack"):
+        client.succeed("nix-thunk pack ~/code/myapp")
+        client.succeed("grep -qF 'git.json' ~/code/myapp/thunk.nix")
+        client.succeed("grep -qF 'myorg' ~/code/myapp/git.json")
+        client.succeed("nix-thunk unpack ~/code/myapp")
+
+      with subtest("nix-thunk can create from ssh remote"):
+        client.succeed("nix-thunk pack ~/code/myapp")
+        client.succeed("nix-thunk create -b master root@githost:/root/myorg/myapp.git ~/code/myapp-remote")
+        client.succeed("diff -u ~/code/myapp/git.json ~/code/myapp-remote/git.json")
+        client.succeed("cmp ~/code/myapp/git.json ~/code/myapp-remote/git.json")
+        client.succeed("nix-thunk unpack ~/code/myapp; nix-thunk unpack ~/code/myapp-remote")
+
+      with subtest("nix-thunk can create from local directory"):
+        client.succeed("nix-thunk create ~/code/myapp ~/code/myapp-local")
+        client.succeed("nix-thunk unpack ~/code/myapp-local")
+
+      with subtest("unpacked thunks can be built"):
+        client.succeed("nix-build ~/code/myapp")
+        client.succeed("nix-build ~/code/myapp-remote")
+        client.succeed("nix-build ~/code/myapp-local")
+
+      with subtest("packed thunks can be built"):
+        client.succeed("nix-thunk -v pack ~/code/myapp-remote; nix-thunk -v pack ~/code/myapp-local")
+        client.succeed("nix-build ~/code/myapp-remote")
+        client.succeed("nix-build ~/code/myapp-local")
+        client.succeed("nix-thunk unpack ~/code/myapp-remote")
+
+      with subtest("nix-thunk can update from ssh remote"):
+        client.succeed("""
+          cd ~/code/myapp;
+          touch test-file;
+          git add test-file;
+          git commit test-file -m "add test file";
+          git push;
+        """)
+        client.succeed("nix-thunk pack ~/code/myapp-remote")
+        client.succeed("nix-thunk update ~/code/myapp-remote")
+        client.succeed("nix-thunk unpack ~/code/myapp-remote")
+        client.succeed("test -f ~/code/myapp-remote/test-file")
+
+      with subtest("nix-thunk can update from local directory"):
+        client.succeed("nix-thunk update ~/code/myapp-local")
+        client.succeed("nix-thunk unpack ~/code/myapp-local")
+        client.succeed("test -f ~/code/myapp-local/test-file")
+      '';
+  }) {}


### PR DESCRIPTION
v6 thunks do not import their nixpkgs so they can not be used outside of the very specific case of fetching GitHub repos that have no submodules.