### PR TITLE
Fetch good nixpkgs tarball from GH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.6.0.0
 
-* [#33](https://github.com/obsidiansystems/nix-thunk/pull/33) Fix an
+* [#34](https://github.com/obsidiansystems/nix-thunk/pull/34) Fix an
   issue where thunks could not be fetched without `nix-thunk` (or one of
   its dependents, e.g. `obelisk`) being installed. Please update all
   your thunks to use the new v8 thunk spec.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Revision history for nix-thunk
 
+## 0.6.0.0
+
+* [#33](https://github.com/obsidiansystems/nix-thunk/pull/33) Fix an
+  issue where thunks could not be fetched without `nix-thunk` (or one of
+  its dependents, e.g. `obelisk`) being installed. Please update all
+  your thunks to use the new v8 thunk spec.
+
+  Updating your thunk can be done by running `nix-thunk unpack $path; nix-thunk pack $path`.
+
 ## 0.5.1.0
 
 * Bump to cli-nix 0.2.0.0; This ensures that `nix-prefetch-git` can always be found.

--- a/default.nix
+++ b/default.nix
@@ -4,13 +4,45 @@
 
 with pkgs.haskell.lib;
 
-let
-  inherit (pkgs) lib;
-  pinnedNixpkgs = builtins.fetchTarball {
+let inherit (pkgs) lib; in rec {
+  # The version of nixpkgs that we use for fetching packing thunks (by
+  # themselves). Not to be used for building packages.
+  packedThunkNixpkgs = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
     sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
   };
-in rec {
+
+  # Override a nix-thunk Cabal package so it knows where nixpkgs is.
+  # This function is exported so that it can be used by downstream
+  # consumers of nix-thunk as a library (e.g. Obelisk).
+  makeRunnableNixThunk = pkg: pkgs.haskell.lib.overrideCabal pkg {
+    librarySystemDepends = with pkgs; [
+      # The correct reaction to this code is "what", followed by
+      # some rather choice words about its author. The answer to
+      # "what":
+      # We need a known-good nixpkgs to be included in nix-thunk's
+      # closure *and* we need to know its path at compile time. The
+      # solution is to generate a tiny, tiny shell script that just
+      # prints the path to that nixpkgs; Nix takes care of making
+      # sure it's a dependency.
+      (writeTextFile {
+        name = "print-nixpkgs-path";
+        text = ''
+          #!/bin/sh
+          echo "${packedThunkNixpkgs}"
+        '';
+        executable = true;
+        destination = "/bin/print-nixpkgs-path";
+      })
+      # You can verify that the nixpkgs was included by doing
+      #
+      #  $ nix-build default.nix -A command
+      #  $ nix path-info -rsSh ./result | grep -source
+      #
+      # and seeing that the closure includes a ~100MiB nixpkgs path.
+    ];
+  };
+
   haskellPackages = pkgs.haskell.packages."${ghc}".override {
     overrides = self: super: {
       which = self.callCabal2nix "which" (thunkSource ./dep/which) {};
@@ -67,7 +99,7 @@ in rec {
         ver = "0.9.1";
         sha256 = "152lnv339fg8nacvyhxjfy2ylppc33ckb6qrgy0vzanisi8pgcvd";
       } {};
-      nix-thunk = self.callCabal2nix "nix-thunk" (gitignoreSource ./.) {};
+      nix-thunk = makeRunnableNixThunk (self.callCabal2nix "nix-thunk" (gitignoreSource ./.) {});
     };
   };
 

--- a/default.nix
+++ b/default.nix
@@ -11,37 +11,6 @@ let
     sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
   };
 in rec {
-  # Override a nix-thunk Cabal package so it knows where nixpkgs is.
-  # This function is exported so that it can be used by downstream
-  # consumers of nix-thunk as a library (e.g. Obelisk).
-  makeRunnableNixThunk = pkg: pkgs.haskell.lib.overrideCabal pkg {
-    librarySystemDepends = with pkgs; [
-      # The correct reaction to this code is "what", followed by
-      # some rather choice words about its author. The answer to
-      # "what":
-      # We need a known-good nixpkgs to be included in nix-thunk's
-      # closure *and* we need to know its path at compile time. The
-      # solution is to generate a tiny, tiny shell script that just
-      # prints the path to that nixpkgs; Nix takes care of making
-      # sure it's a dependency.
-      (writeTextFile {
-        name = "print-nixpkgs-path";
-        text = ''
-          #!/bin/sh
-          echo "${pinnedNixpkgs}"
-        '';
-        executable = true;
-        destination = "/bin/print-nixpkgs-path";
-      })
-      # You can verify that the nixpkgs was included by doing
-      #
-      #  $ nix-build default.nix -A command
-      #  $ nix path-info -rsSh ./result | grep -source
-      #
-      # and seeing that the closure includes a ~100MiB nixpkgs path.
-    ];
-  };
-
   haskellPackages = pkgs.haskell.packages."${ghc}".override {
     overrides = self: super: {
       which = self.callCabal2nix "which" (thunkSource ./dep/which) {};
@@ -98,7 +67,7 @@ in rec {
         ver = "0.9.1";
         sha256 = "152lnv339fg8nacvyhxjfy2ylppc33ckb6qrgy0vzanisi8pgcvd";
       } {};
-      nix-thunk = makeRunnableNixThunk (self.callCabal2nix "nix-thunk" (gitignoreSource ./.) {});
+      nix-thunk = self.callCabal2nix "nix-thunk" (gitignoreSource ./.) {};
     };
   };
 

--- a/dep/cli-extras/thunk.nix
+++ b/dep/cli-extras/thunk.nix
@@ -2,7 +2,10 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import "/nix/store/qjg458n31xk1l6lj26c3b871d4i4is98-source" {}).fetchFromGitHub {
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/cli-git/thunk.nix
+++ b/dep/cli-git/thunk.nix
@@ -2,7 +2,10 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import "/nix/store/qjg458n31xk1l6lj26c3b871d4i4is98-source" {}).fetchFromGitHub {
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/nix-thunk.cabal
+++ b/nix-thunk.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               nix-thunk
-version:            0.5.1.0
+version:            0.6.0.0
 license:            BSD3
 license-file:       LICENSE
 copyright:          Obsidian Systems LLC 2020-2022
@@ -61,8 +61,6 @@ library
     , unix                  >=2.7.2.2  && <2.8
     , which                 >=0.2      && <0.3
     , yaml                  >=0.11.1.2 && <0.12
-    , process               >=1.6.0.0  && <1.7
-    , template-haskell      >=2.14.0.0 && <2.19
 
 executable nix-thunk
   main-is:          src-bin/nix-thunk.hs

--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -103,8 +103,6 @@ import System.IO.Error (isDoesNotExistError)
 import System.IO.Temp
 import System.Posix.Files
 import qualified Text.URI as URI
-import Language.Haskell.TH (Exp(LitE), Lit(StringL), runIO)
-import qualified System.Process as P
 
 --------------------------------------------------------------------------------
 -- Hacks
@@ -300,15 +298,10 @@ attrCacheFileName :: FilePath
 attrCacheFileName = ".attr-cache"
 
 -- | A path from which our known-good nixpkgs can be fetched.
--- @print-nixpkgs-path@ is a shell script whose only purpose is to print
--- that path. It is generated and included in the build dependencies of
--- nix-thunk by our default.nix.
+-- __NOTE__: This path is hardcoded, and only exists so subsumed thunk
+-- specs (v7 specifically) can be parsed.
 pinnedNixpkgsPath :: FilePath
-pinnedNixpkgsPath =
-  $(do
-    p <- fmap init . runIO $ P.readCreateProcess (P.shell "print-nixpkgs-path") ""
-    pure $ LitE $ StringL $ p
-  )
+pinnedNixpkgsPath = "/nix/store/qjg458n31xk1l6lj26c3b871d4i4is98-source"
 
 -- | Specification for how a file in a thunk version works.
 data ThunkFileSpec
@@ -564,8 +557,9 @@ setThunk thunkConfig target gs branch = do
 -- This tool will only ever produce the newest one when it writes a thunk.
 gitHubThunkSpecs :: NonEmpty ThunkSpec
 gitHubThunkSpecs =
-  gitHubThunkSpecV7 :|
-  [ gitHubThunkSpecV6
+  gitHubThunkSpecV8 :|
+  [ gitHubThunkSpecV7
+  , gitHubThunkSpecV6
   , gitHubThunkSpecV5
   , gitHubThunkSpecV4
   , gitHubThunkSpecV3
@@ -677,14 +671,38 @@ let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256
   json = builtins.fromJSON (builtins.readFile ./github.json);
 in fetch json|]
 
+-- | Specification for GitHub thunks which use a specific, pinned
+-- version of nixpkgs for fetching, rather than using @<nixpkgs>@ from
+-- @NIX_PATH@.
+--
+-- Unlike 'gitHubThunKSpecV7', this thunk specification fetches the
+-- nixpkgs tarball from GitHub, so it will fail on environments without
+-- a network connection.
+gitHubThunkSpecV8 :: ThunkSpec
+gitHubThunkSpecV8 = mkThunkSpec "github-v8" "github.json" parseGitHubJsonBytes [here|
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json
+|]
+
 parseGitHubJsonBytes :: LBS.ByteString -> Either String ThunkPtr
 parseGitHubJsonBytes = parseJsonObject $ parseThunkPtr $ \v ->
   ThunkSource_GitHub <$> parseGitHubSource v <|> ThunkSource_Git <$> parseGitSource v
 
 gitThunkSpecs :: NonEmpty ThunkSpec
 gitThunkSpecs =
-  gitThunkSpecV7 :|
-  [ gitThunkSpecV6
+  gitThunkSpecV8 :|
+  [ gitThunkSpecV7
+  , gitThunkSpecV6
   , gitThunkSpecV5
   , gitThunkSpecV4
   , gitThunkSpecV3
@@ -811,6 +829,32 @@ let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, pr
     url = realUrl; inherit rev;
     \${if branch == null then null else "ref"} = branch;
   } else (import ${pinnedNixpkgsPath} {}).fetchgit {
+    url = realUrl; inherit rev sha256;
+  };
+  json = builtins.fromJSON (builtins.readFile ./git.json);
+in fetch json|]
+
+-- | Specification for Git thunks which use a specific, pinned version
+-- version of nixpkgs for fetching, rather than using @<nixpkgs>@ from
+-- @NIX_PATH@.
+--
+-- Unlike 'gitHubThunKSpecV7', this thunk specification fetches the
+-- nixpkgs tarball from GitHub, so it will fail on environments without
+-- a network connection.
+gitThunkSpecV8 :: ThunkSpec
+gitThunkSpecV8 = mkThunkSpec "git-v7" "git.json" parseGitJsonBytes [i|# DO NOT HAND-EDIT THIS FILE
+let fetch = {url, rev, branch ? null, sha256 ? null, fetchSubmodules ? false, private ? false, ...}:
+  let realUrl = let firstChar = builtins.substring 0 1 url; in
+    if firstChar == "/" then /. + url
+    else if firstChar == "." then ./. + url
+    else url;
+  in if !fetchSubmodules && private then builtins.fetchGit {
+    url = realUrl; inherit rev;
+    \${if branch == null then null else "ref"} = branch;
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchgit {
     url = realUrl; inherit rev sha256;
   };
   json = builtins.fromJSON (builtins.readFile ./git.json);

--- a/src/Nix/Thunk/Command.hs
+++ b/src/Nix/Thunk/Command.hs
@@ -34,11 +34,14 @@ thunkPackConfig = ThunkPackConfig
 
 thunkCreateConfig :: Parser ThunkCreateConfig
 thunkCreateConfig = ThunkCreateConfig
-  <$> argument (maybeReader (parseGitUri . T.pack)) (metavar "URI" <> help "Address of the target repository")
+  <$> argument source (metavar "URI" <> help "Address of the target repository")
   <*> optional (strOption (short 'b' <> long "branch" <> metavar "BRANCH" <> help "Point the new thunk at the given branch"))
   <*> optional (option (refFromHexString <$> str) (long "rev" <> long "revision" <> metavar "REVISION" <> help "Point the new thunk at the given revision"))
   <*> thunkConfig
   <*> optional (strArgument (action "directory" <> metavar "DESTINATION" <> help "The name of a new directory to create for the thunk"))
+  where
+    source = (ThunkCreateSource_Absolute <$> maybeReader (parseGitUri . T.pack))
+         <|> (ThunkCreateSource_Relative <$> str)
 
 data ThunkCommand
   = ThunkCommand_Update ThunkUpdateConfig (NonEmpty FilePath)

--- a/tests.nix
+++ b/tests.nix
@@ -72,17 +72,21 @@ in
       start_all()
 
       with subtest("nix-thunk is installed and git can be configured"):
-        client.succeed("nix-thunk --help")
-        client.succeed('git config --global user.email "you@example.com"')
-        client.succeed('git config --global user.name "Your Name"')
+        client.succeed("""
+          nix-thunk --help;
+          git config --global user.email "you@example.com";
+          git config --global user.name "Your Name";
+        """)
 
       githost.wait_for_open_port("22")
 
       with subtest("the clients can access the server via ssh"):
         for machine in [client, noNixThunk]:
-          machine.succeed("mkdir -p ~/.ssh/")
-          machine.succeed("cp ${privateKeyFile} ~/.ssh/id_rsa")
-          machine.succeed("chmod 600 ~/.ssh/id_rsa")
+          machine.succeed("""
+            mkdir -p ~/.ssh/;
+            cp ${privateKeyFile} ~/.ssh/id_rsa;
+            chmod 600 ~/.ssh/id_rsa;
+          """)
           machine.wait_until_succeeds(
             "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa githost true"
           )
@@ -90,49 +94,68 @@ in
           machine.wait_until_succeeds("ssh githost true")
 
       with subtest("a remote bare repo can be started"):
-        githost.succeed("mkdir -p ~/myorg/myapp.git")
-        githost.succeed("cd ~/myorg/myapp.git && git init --bare")
+        githost.succeed("""
+          mkdir -p ~/myorg/myapp.git;
+          cd ~/myorg/myapp.git && git init --bare
+        """)
 
       with subtest("a git project can be configured with a remote using ssh"):
-        client.succeed("mkdir -p ~/code/myapp")
-        client.succeed("cd ~/code/myapp && git init")
-        client.succeed("cp ${thunkableSample} ~/code/myapp/default.nix")
-        client.succeed("cd ~/code/myapp && git add .")
-
-        client.succeed('cd ~/code/myapp && git commit -m "Initial"')
-        client.succeed("cd ~/code/myapp && git remote add origin root@githost:/root/myorg/myapp.git")
+        client.succeed("""
+          mkdir -p ~/code/myapp;
+          cd ~/code/myapp;
+          git init;
+          cp ${thunkableSample} default.nix;
+          git add .;
+          git commit -m 'Initial';
+          git remote add origin root@githost:/root/myorg/myapp.git;
+        """)
 
       with subtest("pushing code to the remote"):
-        client.succeed("cd ~/code/myapp && git push -u origin master")
-        client.succeed("cd ~/code/myapp && git status")
+        client.succeed("""
+          cd ~/code/myapp;
+          git push -u origin master;
+          git status;
+        """)
 
       with subtest("nix-thunk can pack and unpack"):
-        client.succeed("nix-thunk pack ~/code/myapp")
-        client.succeed("grep -qF 'git.json' ~/code/myapp/thunk.nix")
-        client.succeed("grep -qF 'myorg' ~/code/myapp/git.json")
-        client.succeed("nix-thunk unpack ~/code/myapp")
+        client.succeed("""
+          nix-thunk pack ~/code/myapp;
+          grep -qF 'git.json' ~/code/myapp/thunk.nix;
+          grep -qF 'myorg' ~/code/myapp/git.json;
+          nix-thunk unpack ~/code/myapp;
+        """)
 
       with subtest("nix-thunk can create from ssh remote"):
-        client.succeed("nix-thunk pack ~/code/myapp")
-        client.succeed("nix-thunk create -b master root@githost:/root/myorg/myapp.git ~/code/myapp-remote")
-        client.succeed("diff -u ~/code/myapp/git.json ~/code/myapp-remote/git.json")
-        client.succeed("cmp ~/code/myapp/git.json ~/code/myapp-remote/git.json")
-        client.succeed("nix-thunk unpack ~/code/myapp; nix-thunk unpack ~/code/myapp-remote")
+        client.succeed("""
+          nix-thunk pack ~/code/myapp;
+          nix-thunk create -b master root@githost:/root/myorg/myapp.git ~/code/myapp-remote;
+          diff -u ~/code/myapp/git.json ~/code/myapp-remote/git.json;
+          cmp ~/code/myapp/git.json ~/code/myapp-remote/git.json;
+          nix-thunk unpack ~/code/myapp;
+          nix-thunk unpack ~/code/myapp-remote;
+        """)
 
       with subtest("nix-thunk can create from local directory"):
-        client.succeed("nix-thunk create ~/code/myapp ~/code/myapp-local")
-        client.succeed("nix-thunk unpack ~/code/myapp-local")
+        client.succeed("""
+          nix-thunk create ~/code/myapp ~/code/myapp-local
+          nix-thunk unpack ~/code/myapp-local
+        """)
 
       with subtest("unpacked thunks can be built"):
-        client.succeed("nix-build ~/code/myapp")
-        client.succeed("nix-build ~/code/myapp-remote")
-        client.succeed("nix-build ~/code/myapp-local")
+        client.succeed("""
+          nix-build ~/code/myapp;
+          nix-build ~/code/myapp-remote;
+          nix-build ~/code/myapp-local;
+        """)
 
       with subtest("packed thunks can be built"):
-        client.succeed("nix-thunk -v pack ~/code/myapp-remote; nix-thunk -v pack ~/code/myapp-local")
-        client.succeed("nix-build ~/code/myapp-remote")
-        client.succeed("nix-build ~/code/myapp-local")
-        client.succeed("nix-thunk unpack ~/code/myapp-remote")
+        client.succeed("""
+          nix-thunk -v pack ~/code/myapp-remote;
+          nix-thunk -v pack ~/code/myapp-local;
+          nix-build ~/code/myapp-remote;
+          nix-build ~/code/myapp-local;
+          nix-thunk unpack ~/code/myapp-remote;
+        """)
 
       with subtest("nix-thunk can update from ssh remote"):
         client.succeed("""
@@ -141,23 +164,28 @@ in
           git add test-file;
           git commit test-file -m "add test file";
           git push;
+
+          nix-thunk pack ~/code/myapp-remote;
+          nix-thunk update ~/code/myapp-remote;
+          nix-thunk unpack ~/code/myapp-remote;
+          test -f ~/code/myapp-remote/test-file;
         """)
-        client.succeed("nix-thunk pack ~/code/myapp-remote")
-        client.succeed("nix-thunk update ~/code/myapp-remote")
-        client.succeed("nix-thunk unpack ~/code/myapp-remote")
-        client.succeed("test -f ~/code/myapp-remote/test-file")
 
       with subtest("nix-thunk can update from local directory"):
-        client.succeed("nix-thunk update ~/code/myapp-local")
-        client.succeed("nix-thunk unpack ~/code/myapp-local")
-        client.succeed("test -f ~/code/myapp-local/test-file")
+        client.succeed("""
+          nix-thunk update ~/code/myapp-local;
+          nix-thunk unpack ~/code/myapp-local;
+          test -f ~/code/myapp-local/test-file;
+        """)
 
-      # This test is a bit... dirty. We can't create the thunk on
-      # 'noNixThunk', that's the whole point. We can't create the thunk
-      # in this nix file, because [mumble] nix-prefetch-git doesn't work
-      # inside the sandbox. But you know what we *can* do? Move the
-      # thunk from one machine to the other. And since we already have
-      # Git...
+      with subtest("nix-thunk pack will not destroy changes"):
+        client.succeed("""
+          cd ~/code/myapp-local;
+          echo "# Some change" >> default.nix;
+          nix-build
+        """);
+        client.fail("nix-thunk pack ~/code/myapp-local;")
+
       with subtest("packed thunks can be built without nix-thunk"):
         client.succeed("""
           nix-thunk pack ~/code/myapp-remote;


### PR DESCRIPTION
* Adds a new v8 thunk spec which fetches nixpkgs from github.
* Adds automated to tests to make sure thunks can be built on machines without nix-thunk.