### PR TITLE
Determine remote using git-config when branch.<name>.merge option is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
   Updating your thunk can be done by running `nix-thunk unpack $path; nix-thunk pack $path`.
 
+* [#35](https://github.com/obsidiansystems/nix-thunk/pull/35) Determine remote using git-config when `branch.<name>.merge` option is set
+  (Fixes [obelisk#792](https://github.com/obsidiansystems/obelisk/issues/792).)
+
 ## 0.5.1.0
 
 * Bump to cli-nix 0.2.0.0; This ensures that `nix-prefetch-git` can always be found.

--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -1170,7 +1170,8 @@ getThunkPtr gitCheckClean dir mPrivate = do
             [b, _] -> do
               remote <- T.strip <$> readGitProcess thunkDir ["config", "--get", T.unpack ("branch." <> b <> ".remote")]
               pure (Just (remote <> T.singleton '/' <> b, remote))
-            -- If it doesn't have that option set then we're SOL
+            -- If the branch does not have a value for that setting then
+            -- we're out of luck
             _ -> pure Nothing
         [u, r] -> pure $ Just (u, r)
         (_:_) -> failWith "git for-each-ref invalid output"

--- a/tests.nix
+++ b/tests.nix
@@ -195,5 +195,15 @@ in
           rsync -avx githost:myapp-remote .;
           nix-build myapp-remote
         """)
+
+      with subtest("nix-thunk can create from ssh remote, with branch.master.merge set"):
+        client.succeed("""
+          git config --global branch.master.merge master;
+          nix-thunk pack ~/code/myapp;
+          nix-thunk create -b master root@githost:/root/myorg/myapp.git ~/code/myapp-remote-merge-master;
+          diff -u ~/code/myapp/git.json ~/code/myapp-remote-merge-master/git.json;
+          cmp ~/code/myapp/git.json ~/code/myapp-remote-merge-master/git.json;
+          nix-thunk unpack ~/code/myapp
+        """)
       '';
   }) {}


### PR DESCRIPTION
Fixes https://github.com/obsidiansystems/obelisk/issues/792: When `branch.master.merge` is set, `for-each-ref` doesn't print the remote, but we can piece the remote ref together by looking at `$(git config branch.master.remote)/$(git config branch.master.merge)`. 