### PR TITLE
Disable time-compat tests to allow build on WSL

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -88,11 +88,13 @@ let inherit (pkgs) lib; in rec {
       ver = "0.11.1";
       sha256 = "1xsh4mcrmgiavgnkb5bg5lzxj1546525ffxjms3rlagf4jh9sn1i";
     } {};
-    time-compat = self.callHackageDirect {
+    # When built on WSL, the tests fail for this package.
+    # We do not officially support WSL, but this is a small affordance.
+    time-compat = pkgs.haskell.lib.dontCheck (self.callHackageDirect {
       pkg = "time-compat";
       ver = "1.9.5";
       sha256 = "0xy044x713bbvl8i1180bnccn60ji1n7mw1scs9ydy615bgwr82c";
-    } {};
+    } {});
     ansi-terminal = self.callHackageDirect {
       pkg = "ansi-terminal";
       ver = "0.9.1";


### PR DESCRIPTION
We do not officially support WSL, but this is a simple way to enable it.
We will not try very hard to keep nix-thunk building on WSL.

See #23 #24 