### PR TITLE
Ignore user's git configuration when shelling out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for nix-thunk
 
+## Unreleased
+
+* [#42](https://github.com/obsidiansystems/nix-thunk/pull/42) Thunk read errors are now presented in a more informative manner.
+* [#43](https://github.com/obsidiansystems/nix-thunk/pull/43) `nix-thunk` will now ensure that any `git` processes invoked during its execution have a clean configuration. 
+  This prevents `nix-thunk` crashing when e.g. the user's configuration `git` is valid only in a version newer than what `nix-thunk` links against, and works towards making thunks more reproducible by ensuring that thunk URIs are resolvable independently of the user's environment.
+
 ## 0.6.1.0
 
 * [#36](https://github.com/obsidiansystems/nix-thunk/pull/36) Expose the internals of the `nix-thunk` library.

--- a/src/Nix/Thunk/Internal.hs
+++ b/src/Nix/Thunk/Internal.hs
@@ -1053,7 +1053,8 @@ gitCloneForThunkUnpack gitSrc commit dir = do
     void $ readGitProcess dir ["submodule", "update", "--recursive", "--init"]
 
 -- | Read a git process ignoring the global configuration. This isn't as
--- locked-down as 'isolateGitProc' for usability reasons, but it still
+-- locked-down as 'isolateGitProc' to make sure the Git process can
+-- still interact with the user (e.g. @ssh-askpass@), but it still
 -- ignores enough of the configuration to ensure that thunks are
 -- reproducible.
 readGitProcess :: MonadNixThunk m => FilePath -> [String] -> m Text

--- a/src/Nix/Thunk/Internal.hs
+++ b/src/Nix/Thunk/Internal.hs
@@ -16,6 +16,15 @@ module Nix.Thunk.Internal where
 
 import Bindings.Cli.Coreutils (cp)
 import Bindings.Cli.Git
+    ( ensureCleanGitRepo,
+      gitLookupCommitForRef,
+      gitLookupDefaultBranch,
+      gitLsRemote,
+      gitProc,
+      gitProcNoRepo,
+      isolateGitProc,
+      CommitId,
+      GitRef(GitRef_Branch) )
 import Bindings.Cli.Nix
 import Cli.Extras
 import Control.Applicative
@@ -1034,15 +1043,32 @@ gitCloneForThunkUnpack
   -> FilePath -- ^ Directory to clone into
   -> m ()
 gitCloneForThunkUnpack gitSrc commit dir = do
-  let git = callProcessAndLogOutput (Notice, Notice) . gitProc dir
-  git $ [ "clone" ]
+  _ <- readGitProcess dir $ [ "clone" ]
     ++  ["--recursive" | _gitSource_fetchSubmodules gitSrc]
     ++  [ T.unpack $ gitUriToText $ _gitSource_url gitSrc ]
     ++  do branch <- maybeToList $ _gitSource_branch gitSrc
            [ "--branch", T.unpack $ untagName branch ]
-  git ["reset", "--hard", refToHexString commit]
+  _ <- readGitProcess dir ["reset", "--hard", refToHexString commit]
   when (_gitSource_fetchSubmodules gitSrc) $
-    git ["submodule", "update", "--recursive", "--init"]
+    void $ readGitProcess dir ["submodule", "update", "--recursive", "--init"]
+
+-- | Read a git process ignoring the global configuration. This isn't as
+-- locked-down as 'isolateGitProc' for usability reasons, but it still
+-- ignores enough of the configuration to ensure that thunks are
+-- reproducible.
+readGitProcess :: MonadNixThunk m => FilePath -> [String] -> m Text
+readGitProcess dir = readProcessAndLogOutput (Notice, Notice) . setEnvOverride (envfix <>) . gitProc dir
+  where
+    -- Ignore both global (user's) and system (... system-wide) git
+    -- configuration.
+    envfix = Map.fromList
+      [ ("GIT_CONFIG_NOSYSTEM", "yes")
+      -- Git documentation says GIT_CONFIG_GLOBAL=/dev/null should
+      -- prevent it from reading the global config file but that's a
+      -- lie, actually.
+      , ("HOME", "/dev/null")
+      , ("XDG_CONFIG_HOME", "/dev/null")
+      ]
 
 --TODO: add a rollback mode to pack to the original thunk
 packThunk :: MonadNixThunk m => ThunkPackConfig -> FilePath -> m ThunkPtr
@@ -1126,19 +1152,7 @@ getThunkPtr gitCheckClean dir mPrivate = do
     <- fmap Map.fromList $ forM headDump $ \line -> do
       (branch : restOfLine) <- pure $ T.words line
       mUpstream <- case restOfLine of
-        [] -> do
-          -- Obelisk issue #792: If this branch has a
-          -- branch.<branch>.merge config Git option, we won't be able
-          -- to use for-each-ref to get its remote. But we can still get
-          -- the remote by piecing toegher "git conifg" output:
-          branchMergeCfg <- readGitProcess thunkDir ["config", "--get-all", T.unpack ("branch." <> branch <> ".merge")]
-          case T.lines branchMergeCfg of
-            [b, _] -> do
-              remote <- T.strip <$> readGitProcess thunkDir ["config", "--get", T.unpack ("branch." <> b <> ".remote")]
-              pure (Just (remote <> T.singleton '/' <> b, remote))
-            -- If the branch does not have a value for that setting then
-            -- we're out of luck
-            _ -> pure Nothing
+        [] -> pure Nothing
         [u, r] -> pure $ Just (u, r)
         (_:_) -> failWith "git for-each-ref invalid output"
       pure (branch, mUpstream)


### PR DESCRIPTION
Prevents two classes of issues:

1. A thunk works because of the user's git configuration, but does not work when built with nix. This can happen with e.g. `url.*.insteadof` causing `nix-thunk` to be able to resolve the URL, but not the nix builder.
2. The user's git configuration might have settings that only become valid in a version of Git newer than the one we're using (ran into this personally which is what prompted this fix).

Reverts #35 since it's impossible for `branch.*.merge` to be set to a non-standard value when cloning thunks. 