### PR TITLE
Pure eval

### DIFF
--- a/dep/gitignore.nix/github.json
+++ b/dep/gitignore.nix/github.json
@@ -3,6 +3,6 @@
   "repo": "gitignore.nix",
   "branch": "master",
   "private": false,
-  "rev": "7415c4feb127845553943a3856cbc5cb967ee5e0",
-  "sha256": "1zd1ylgkndbb5szji32ivfhwh04mr1sbgrnvbrqpmfb67g2g3r9i"
+  "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+  "sha256": "sha256:07vg2i9va38zbld9abs9lzqblz193vc5wvqd6h7amkmwf66ljcgh"
 }


### PR DESCRIPTION
Update gitignore.nix to make it not search impure paths outside of the installed system configuration ('/etc/nixos' or home-manager)

Currently the (old) gitignorenix we uses searches through ~/.gitignore which fails with pure eval