### PR TITLE
Swap `default.nix` and `lib.nix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ nix-thunk update some-dep
 
 ## Nix Usage
 
-The [`lib.nix`](lib.nix) file in this repository defines the nix function, `thunkSource`.
+The [`default.nix`](default.nix) file in this repository defines the nix function, `thunkSource`.
 This can be used in your nix files to access the contents of thunks.
 In the following example, a thunk is used in place of the source location argument to `callCabal2nix`.
 `thunkSource` works whether the thunk is packed or unpacked, making it convenient to run nix commands with modified thunks.

--- a/default.nix
+++ b/default.nix
@@ -1,75 +1,64 @@
-# This file is for building `nix-thunk` with arbitrary GHC, currently
-# using `haskell.nix`. For *using* `nix-thunk`, you just need `lib.nix`.
+# This file is intended to be used in the Nix code of projects using
+# `nix-thunk`. As such, it is supposed to be very stable.
 #
-# This file just includes `lib.nix` for backwards compat (and likewise
-# contains the deprecated lib functions for the same reason).
+# Packed thunks are self-contained, but the intended use-case of
+# `nix-thunk` is that the ambient project should be able to use the
+# thunk whether it is unpacked or not. That is a bit more tricky, and so
+# that is what these functions help with.
 
-{ haskell-nix ? import ./dep/haskell.nix {}
-, pkgs ? import haskell-nix.sources.nixpkgs haskell-nix.nixpkgsArgs
-, ghc ? (import ./versions.nix).ghc.preferred
+{
+  lib ? pkgs.lib,
+  pkgs,
+  gitignoreSource ?
+    (import ./dep/gitignore.nix { inherit lib; }).gitignoreSource,
 }:
 
-with pkgs.haskell.lib;
+rec {
+  # Retrieve source that is controlled by the hack-* scripts; it may be either a
+  # stub or a checked-out git repo
+  thunkSource = p:
+    let
+      contents = builtins.readDir p;
 
-let inherit (pkgs) lib;
-    postInstallGenerateOptparseApplicativeCompletion = exeName: ''
-      bashCompDir="''${!outputBin}/share/bash-completion/completions"
-      zshCompDir="''${!outputBin}/share/zsh/vendor-completions"
-      fishCompDir="''${!outputBin}/share/fish/vendor_completions.d"
-      mkdir -p "$bashCompDir" "$zshCompDir" "$fishCompDir"
-      "''${!outputBin}/bin/${exeName}" --bash-completion-script "''${!outputBin}/bin/${exeName}" >"$bashCompDir/${exeName}"
-      "''${!outputBin}/bin/${exeName}" --zsh-completion-script "''${!outputBin}/bin/${exeName}" >"$zshCompDir/_${exeName}"
-      "''${!outputBin}/bin/${exeName}" --fish-completion-script "''${!outputBin}/bin/${exeName}" >"$fishCompDir/${exeName}.fish"
-      # Sanity check
-      grep -F ${exeName} <$bashCompDir/${exeName} >/dev/null || {
-        echo 'Could not find ${exeName} in completion script.'
-        exit 1
-      }
-    '';
-in rec {
-  # The Haskell.nix project that is used to build this by default
-  project = pkgs.haskell-nix.project {
-    src = pkgs.haskell-nix.haskellLib.cleanGit {
-      name = "nix-thunk";
-      src = ./.;
-    };
-    compiler-nix-name = ghc;
-    modules = [
-      ({...}: {
-        packages.cli-git.components.library.build-tools = [
-          pkgs.git
-        ];
-        packages.cli-nix.components.library.build-tools = [
-          pkgs.nix-prefetch-git
-          pkgs.nix # For nix-prefetch-url
-        ];
-        packages.nix-thunk.components.exes.nix-thunk = {
-          enableStatic = true;
-          postInstall = postInstallGenerateOptparseApplicativeCompletion "nix-thunk";
-        };
-      })
-    ];
-  };
+      contentsMatch = { required, optional }:
+           (let all = required // optional; in all // contents == all)
+        && builtins.intersectAttrs required contents == required;
 
-  # The nix-thunk command itself; if you just want to use nix-thunk, this is the
-  # thing to install
-  command = project.nix-thunk.components.exes.nix-thunk;
+      # Newer obelisk thunks include the feature of hackGet with a thunk.nix file in the thunk.
+      isObeliskThunkWithThunkNix =
+        let
+          packed = jsonFileName: {
+            required = { ${jsonFileName} = "regular"; "default.nix" = "regular"; "thunk.nix" = "regular"; };
+            optional = { ".attr-cache" = "directory"; };
+          };
+        in builtins.any (n: contentsMatch (packed n)) [ "git.json" "github.json" ];
 
-  inherit (import ./dep/gitignore.nix { inherit lib; }) gitignoreSource;
+      filterArgs = x: removeAttrs x [ "branch" ];
+      hasValidThunk = name: if builtins.pathExists (p + ("/" + name))
+        then
+          contentsMatch {
+            required = { ${name} = "regular"; };
+            optional = { "default.nix" = "regular"; ".attr-cache" = "directory"; };
+          }
+          || throw "Thunk at ${toString p} has files in addition to ${name} and optionally default.nix and .attr-cache. Remove either ${name} or those other files to continue (check for leftover .git too)."
+        else false;
+    in
+      if isObeliskThunkWithThunkNix then import (p + "/thunk.nix")
+      else if hasValidThunk "git.json" then (
+        let gitArgs = filterArgs (builtins.fromJSON (builtins.readFile (p + "/git.json")));
+        in if builtins.elem "@" (lib.stringToCharacters gitArgs.url)
+          then pkgs.fetchgitPrivate gitArgs
+          else pkgs.fetchgit gitArgs
+        )
+      else if hasValidThunk "github.json" then
+        pkgs.fetchFromGitHub (filterArgs (builtins.fromJSON (builtins.readFile (p + "/github.json"))))
+      else {
+        name = baseNameOf p;
+        outPath = gitignoreSource p;
+      };
 
-  inherit (import ./lib.nix { inherit pkgs gitignoreSource; })
-    thunkSource
-    mapSubdirectories
-    ;
-
-  # The version of nixpkgs that we use for fetching packing thunks (by
-  # themselves). If you need to ensure that nix-thunk will work without a
-  # network connection, make sure this is in your nix store. Not to be used for
-  # building packages.
-  packedThunkNixpkgs = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
-    sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
-  };
+  #TODO: This really shouldn't include *all* symlinks, just ones that point at directories
+  mapSubdirectories = f: dir: lib.mapAttrs (name: _: f (dir + "/${name}")) (lib.filterAttrs (_: type: type == "directory" || type == "symlink") (builtins.readDir dir));
 
   ##############################################################################
   # Deprecated functions

--- a/lib.nix
+++ b/lib.nix
@@ -1,63 +1,73 @@
-# This file is intended to be used in the Nix code of projects using
-# `nix-thunk`. As such, it is supposed to be very stable.
+# This file is for building `nix-thunk` with arbitrary GHC, currently
+# using `haskell.nix`. For *using* `nix-thunk`, you just need `default.nix`.
 #
-# Packed thunks are self-contained, but the intended use-case of
-# `nix-thunk` is that the ambient project should be able to use the
-# thunk whether it is unpacked or not. That is a bit more tricky, and so
-# that is what these functions help with.
+# This file is UNSTABLE, and should not be used in downstream projects
+# accordingly.
 
-{
-  lib ? pkgs.lib,
-  pkgs,
-  gitignoreSource ?
-    (import ./dep/gitignore.nix { inherit lib; }).gitignoreSource,
+{ haskell-nix ? import ./dep/haskell.nix {}
+, pkgs ? import haskell-nix.sources.nixpkgs haskell-nix.nixpkgsArgs
+, ghc ? (import ./versions.nix).ghc.preferred
 }:
 
-{
-  # Retrieve source that is controlled by the hack-* scripts; it may be either a
-  # stub or a checked-out git repo
-  thunkSource = p:
-    let
-      contents = builtins.readDir p;
+with pkgs.haskell.lib;
 
-      contentsMatch = { required, optional }:
-           (let all = required // optional; in all // contents == all)
-        && builtins.intersectAttrs required contents == required;
+let inherit (pkgs) lib;
+    postInstallGenerateOptparseApplicativeCompletion = exeName: ''
+      bashCompDir="''${!outputBin}/share/bash-completion/completions"
+      zshCompDir="''${!outputBin}/share/zsh/vendor-completions"
+      fishCompDir="''${!outputBin}/share/fish/vendor_completions.d"
+      mkdir -p "$bashCompDir" "$zshCompDir" "$fishCompDir"
+      "''${!outputBin}/bin/${exeName}" --bash-completion-script "''${!outputBin}/bin/${exeName}" >"$bashCompDir/${exeName}"
+      "''${!outputBin}/bin/${exeName}" --zsh-completion-script "''${!outputBin}/bin/${exeName}" >"$zshCompDir/_${exeName}"
+      "''${!outputBin}/bin/${exeName}" --fish-completion-script "''${!outputBin}/bin/${exeName}" >"$fishCompDir/${exeName}.fish"
+      # Sanity check
+      grep -F ${exeName} <$bashCompDir/${exeName} >/dev/null || {
+        echo 'Could not find ${exeName} in completion script.'
+        exit 1
+      }
+    '';
+in rec {
+  # The Haskell.nix project that is used to build this by default
+  project = pkgs.haskell-nix.project {
+    src = pkgs.haskell-nix.haskellLib.cleanGit {
+      name = "nix-thunk";
+      src = ./.;
+    };
+    compiler-nix-name = ghc;
+    modules = [
+      ({...}: {
+        packages.cli-git.components.library.build-tools = [
+          pkgs.git
+        ];
+        packages.cli-nix.components.library.build-tools = [
+          pkgs.nix-prefetch-git
+          pkgs.nix # For nix-prefetch-url
+        ];
+        packages.nix-thunk.components.exes.nix-thunk = {
+          enableStatic = true;
+          postInstall = postInstallGenerateOptparseApplicativeCompletion "nix-thunk";
+        };
+      })
+    ];
+  };
 
-      # Newer obelisk thunks include the feature of hackGet with a thunk.nix file in the thunk.
-      isObeliskThunkWithThunkNix =
-        let
-          packed = jsonFileName: {
-            required = { ${jsonFileName} = "regular"; "default.nix" = "regular"; "thunk.nix" = "regular"; };
-            optional = { ".attr-cache" = "directory"; };
-          };
-        in builtins.any (n: contentsMatch (packed n)) [ "git.json" "github.json" ];
+  # The nix-thunk command itself; if you just want to use nix-thunk, this is the
+  # thing to install
+  command = project.nix-thunk.components.exes.nix-thunk;
 
-      filterArgs = x: removeAttrs x [ "branch" ];
-      hasValidThunk = name: if builtins.pathExists (p + ("/" + name))
-        then
-          contentsMatch {
-            required = { ${name} = "regular"; };
-            optional = { "default.nix" = "regular"; ".attr-cache" = "directory"; };
-          }
-          || throw "Thunk at ${toString p} has files in addition to ${name} and optionally default.nix and .attr-cache. Remove either ${name} or those other files to continue (check for leftover .git too)."
-        else false;
-    in
-      if isObeliskThunkWithThunkNix then import (p + "/thunk.nix")
-      else if hasValidThunk "git.json" then (
-        let gitArgs = filterArgs (builtins.fromJSON (builtins.readFile (p + "/git.json")));
-        in if builtins.elem "@" (lib.stringToCharacters gitArgs.url)
-          then pkgs.fetchgitPrivate gitArgs
-          else pkgs.fetchgit gitArgs
-        )
-      else if hasValidThunk "github.json" then
-        pkgs.fetchFromGitHub (filterArgs (builtins.fromJSON (builtins.readFile (p + "/github.json"))))
-      else {
-        name = baseNameOf p;
-        outPath = gitignoreSource p;
-      };
+  inherit (import ./dep/gitignore.nix { inherit lib; }) gitignoreSource;
 
-  #TODO: This really shouldn't include *all* symlinks, just ones that point at directories
-  mapSubdirectories = f: dir: lib.mapAttrs (name: _: f (dir + "/${name}")) (lib.filterAttrs (_: type: type == "directory" || type == "symlink") (builtins.readDir dir));
+  inherit (import ./. { inherit pkgs gitignoreSource; })
+    thunkSource
+    mapSubdirectories
+    ;
 
+  # The version of nixpkgs that we use for fetching packing thunks (by
+  # themselves). If you need to ensure that nix-thunk will work without a
+  # network connection, make sure this is in your nix store. Not to be used for
+  # building packages.
+  packedThunkNixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+    sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+  };
 }

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 let versions = import ./versions.nix;
     instances = builtins.listToAttrs (map (ghcVersion: {
       name = ghcVersion;
-      value = import ./default.nix { ghc = ghcVersion; };
+      value = import ./lib.nix { ghc = ghcVersion; };
     }) versions.ghc.supported);
     preferredInstance = instances.${versions.ghc.preferred};
     pkgs = preferredInstance.project.pkgs;

--- a/tests.nix
+++ b/tests.nix
@@ -138,11 +138,11 @@ in
 
       with subtest("thunkSource works on unpacked thunk"):
         client.succeed("""
-          cp ${./lib.nix} ~/code/lib.nix;
+          cp ${./default.nix} ~/code/default.nix;
 
           # Actual `gitignore.nix` is hard to use without internet.
           # `builtins.fetchgit` will do as a filter-er.
-          nix-instantiate --eval --expr --strict '(import ~/code/lib.nix { pkgs = import <nixpkgs> {}; gitignoreSource = builtins.fetchGit; }).thunkSource ~/code/myapp';
+          nix-instantiate --eval --expr --strict '(import ~/code/default.nix { pkgs = import <nixpkgs> {}; gitignoreSource = builtins.fetchGit; }).thunkSource ~/code/myapp';
         """)
 
       with subtest("thunkSource works on packed thunk"):
@@ -151,7 +151,7 @@ in
 
           # Actual `gitignore.nix` is hard to use without internet. But
           # we don't need it in this case.
-          nix-instantiate --eval --expr --strict '(import ~/code/lib.nix { pkgs = import <nixpkgs> {}; gitignoreSource = _: throw "unused"; }).thunkSource ~/code/myapp';
+          nix-instantiate --eval --expr --strict '(import ~/code/default.nix { pkgs = import <nixpkgs> {}; gitignoreSource = _: throw "unused"; }).thunkSource ~/code/myapp';
 
           nix-thunk unpack ~/code/myapp;
         """)


### PR DESCRIPTION
`default.nix` is the stable one now

As discussed starting in #60 and then futher in private, we want to keep `default.nix` the main entry point.