### PR TITLE
Filter down to the haskell source for the haskell package

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -28,22 +28,9 @@ rec {
       }
     '';
 
-  repoSource = pkgs.haskell-nix.haskellLib.cleanGit {
+  haskellPackageSource = pkgs.haskell-nix.haskellLib.cleanGit {
     name = "nix-thunk";
     src = ./.;
-  };
-
-  haskellPackageSource = lib.fileset.toSource {
-    fileset = lib.fileset.intersection
-      (lib.fileset.fromSource repoSource)
-      (lib.fileset.unions [
-        ./LICENSE
-        ./CHANGELOG.md
-        ./README.md
-        ./nix-thunk.cabal
-        (lib.fileset.fileFilter (file: file.hasExt "hs") ./.)
-      ]);
-    root = ./.;
   };
 
   perGhc =

--- a/lib.nix
+++ b/lib.nix
@@ -8,10 +8,12 @@
 , pkgs ? import haskell-nix.sources.nixpkgs haskell-nix.nixpkgsArgs
 }:
 
-with pkgs.haskell.lib;
+rec {
+  inherit haskell-nix pkgs;
 
-let inherit (pkgs) lib;
-    postInstallGenerateOptparseApplicativeCompletion = exeName: ''
+  inherit (pkgs) lib;
+
+  postInstallGenerateOptparseApplicativeCompletion = exeName: ''
       bashCompDir="''${!outputBin}/share/bash-completion/completions"
       zshCompDir="''${!outputBin}/share/zsh/vendor-completions"
       fishCompDir="''${!outputBin}/share/fish/vendor_completions.d"
@@ -25,10 +27,23 @@ let inherit (pkgs) lib;
         exit 1
       }
     '';
-in rec {
-  src = pkgs.haskell-nix.haskellLib.cleanGit {
+
+  repoSource = pkgs.haskell-nix.haskellLib.cleanGit {
     name = "nix-thunk";
     src = ./.;
+  };
+
+  haskellPackageSource = lib.fileset.toSource {
+    fileset = lib.fileset.intersection
+      (lib.fileset.fromSource repoSource)
+      (lib.fileset.unions [
+        ./LICENSE
+        ./CHANGELOG.md
+        ./README.md
+        ./nix-thunk.cabal
+        (lib.fileset.fileFilter (file: file.hasExt "hs") ./.)
+      ]);
+    root = ./.;
   };
 
   perGhc =
@@ -37,7 +52,7 @@ in rec {
     rec {
       # The Haskell.nix project that is used to build this by default
       project = pkgs.haskell-nix.project {
-        inherit src;
+        src = haskellPackageSource;
         compiler-nix-name = ghc;
         modules = [
           ({...}: {

--- a/release.nix
+++ b/release.nix
@@ -21,15 +21,14 @@ in {
     { recurseForDerivations = true; };
 
   check-hlint = pkgs.runCommand "check-hlint" {
-    src = nix-thunk.src;
+    src = nix-thunk.haskellPackageSource;
     buildInputs = [
       (preferredInstance.project.tool "hlint" "latest")
     ];
   } ''
     set -euo pipefail
 
-    cd "$src"
-    hlint .
+    hlint --hint=${./.hlint.yaml} "$src"
 
     touch "$out" # Make the derivation succeed if we get this far
   '';


### PR DESCRIPTION
This means nix file changes won't cause pointless rebuilds