### PR TITLE
Use SSH for private GitHub repos in thunkSourceToGitSource

### DIFF
--- a/src/Nix/Thunk/Internal.hs
+++ b/src/Nix/Thunk/Internal.hs
@@ -154,7 +154,7 @@ data ThunkSource
 
 thunkSourceToGitSource :: ThunkSource -> GitSource
 thunkSourceToGitSource = \case
-  ThunkSource_GitHub s -> forgetGithub False s
+  ThunkSource_GitHub s -> forgetGithub (_gitHubSource_private s) s
   ThunkSource_Git s -> s
 
 setThunkSourceBranch :: Maybe (Name Branch) -> ThunkSource -> ThunkSource


### PR DESCRIPTION
thunkSourceToGitSource hardcodes forgetGithub False, so private repos always get HTTPS URLs and prompt for credentials. This uses _gitHubSource_private instead, matching the existing behavior at line 1443.